### PR TITLE
Fix global $fs setting

### DIFF
--- a/sys/globals.go
+++ b/sys/globals.go
@@ -8,18 +8,15 @@ import (
 	"fmt"
 )
 
-var fa float64 = 2.0
-var fs float64 = 2.0
-var fn uint16 = 0
-var uses = []string{}
+// According to the docs:
+// https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#.24fa.2C_.24fs_and_.24fn
+var (
+	fa float64 = 12.0
+	fs float64 = 2.0
+	fn uint16  = 0
+)
 
-func init() {
-	// According to the docs:
-	// https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#.24fa.2C_.24fs_and_.24fn
-	fa = 12.0
-	fs = 2.0
-	fn = 0
-}
+var uses = []string{}
 
 // Minimum angle for a fragment. Ignored if number of fragments setting is non-zero.
 func SetFa(val float64) {
@@ -34,8 +31,7 @@ func SetFs(val float64) {
 	if val < 0.01 {
 		val = 0.01
 	}
-	fa = val
-
+	fs = val
 }
 
 // Number of fragments for the full circle. If zero other fragment settings apply.


### PR DESCRIPTION
The global `sys.SetFs` did not set the fs but the fa variable.  
Also the default setting in the init-block is redundant (and inconsistent) with the variable initialization above it.
